### PR TITLE
Add feature flags to ASDF system defintion

### DIFF
--- a/nibbles.asd
+++ b/nibbles.asd
@@ -39,11 +39,14 @@
                                      (:txt-file "nibbles-doc")
                                      (:css-file "style")))
                (:module "sbcl-opt"
-                        :depends-on ("package" "macro-utils")
-                        :components ((:file "fndb")
-                                     (:file "nib-tran" :depends-on ("fndb"))
-                                     (:file "x86-vm" :depends-on ("fndb"))
-                                     (:file "x86-64-vm" :depends-on ("fndb")))))
+                :depends-on ("package" "macro-utils")
+                :if-feature :sbcl
+                :components ((:file "fndb")
+                             (:file "nib-tran" :depends-on ("fndb"))
+                             (:file "x86-vm" :depends-on ("fndb")
+                              :if-feature :x86)
+                             (:file "x86-64-vm" :depends-on ("fndb")
+                              :if-feature :x86-64))))
   :in-order-to ((asdf:test-op (asdf:test-op "nibbles/tests"))))
 
 (asdf:defsystem "nibbles/tests"

--- a/sbcl-opt/fndb.lisp
+++ b/sbcl-opt/fndb.lisp
@@ -1,13 +1,11 @@
 ;;;; fndb.lisp -- DEFKNOWNish bits for SBCL
 
-(cl:in-package :nibbles)
+(cl:in-package #:nibbles)
 
-#+sbcl (progn
-
-;;; Efficient array bounds checking
+ ;;; Efficient array bounds checking
 (sb-c:defknown %check-bound
-  ((simple-array (unsigned-byte 8) (*)) index (and fixnum sb-vm:word)
-   (member 2 4 8 16))
+    ((simple-array (unsigned-byte 8) (*)) index (and fixnum sb-vm:word)
+     (member 2 4 8 16))
     index (sb-c:any) :overwrite-fndb-silently t)
 
 ;; We DEFKNOWN the exported functions so we can DEFTRANSFORM them.
@@ -41,5 +39,3 @@
                      ,internal-arg-types
                      ,arg-type (sb-c:any) :overwrite-fndb-silently t) into defknowns
         finally (return `(progn ,@defknowns)))
-
-);#+sbcl

--- a/sbcl-opt/nib-tran.lisp
+++ b/sbcl-opt/nib-tran.lisp
@@ -1,27 +1,25 @@
 ;;;; nib-tran.lisp -- DEFTRANSFORMs for SBCL
 
-(cl:in-package :nibbles)
-
-#+sbcl (progn
+(cl:in-package #:nibbles)
 
 (sb-c:deftransform %check-bound ((vector bound offset n-bytes)
-				 ((simple-array (unsigned-byte 8) (*)) index
-				  (and fixnum sb-vm:word)
-				  (member 2 4 8 16))
-				 * :node node)
+                                 ((simple-array (unsigned-byte 8) (*)) index
+                                  (and fixnum sb-vm:word)
+                                  (member 2 4 8 16))
+                                 * :node node)
   "optimize away bounds check"
   ;; cf. sb-c::%check-bound transform
   (cond ((sb-c:policy node (= sb-c::insert-array-bounds-checks 0))
-	 'offset)
-	((not (sb-c::constant-lvar-p bound))
-	 (sb-c::give-up-ir1-transform))
-	(t
-	 (let* ((dim (sb-c::lvar-value bound))
-		(n-bytes (sb-c::lvar-value n-bytes))
-		(upper-bound `(integer 0 (,(- dim n-bytes -1)))))
-	   (if (> n-bytes dim)
-	       (sb-c::give-up-ir1-transform)
-	       `(the ,upper-bound offset))))))
+         'offset)
+        ((not (sb-c::constant-lvar-p bound))
+         (sb-c::give-up-ir1-transform))
+        (t
+         (let* ((dim (sb-c::lvar-value bound))
+                (n-bytes (sb-c::lvar-value n-bytes))
+                (upper-bound `(integer 0 (,(- dim n-bytes -1)))))
+           (if (> n-bytes dim)
+               (sb-c::give-up-ir1-transform)
+               `(the ,upper-bound offset))))))
 
 #.(flet ((specialized-includep (bitsize signedp setterp)
            (declare (ignorable bitsize signedp setterp))
@@ -34,13 +32,13 @@
            #+(or x86 x86-64)
            t)
          (generic-transform-form (fun-name arglist n-bytes
-                                           setterp signedp big-endian-p)
+                                  setterp signedp big-endian-p)
            (let ((offset-type `(integer 0 ,(- array-dimension-limit n-bytes))))
-           `(sb-c:deftransform ,fun-name ,arglist
-              `(locally (declare (type ,',offset-type offset))
-		 ,',(if setterp
-			(set-form 'vector 'offset 'value n-bytes big-endian-p)
-			(ref-form 'vector 'offset n-bytes signedp big-endian-p)))))))
+             `(sb-c:deftransform ,fun-name ,arglist
+                `(locally (declare (type ,',offset-type offset))
+                   ,',(if setterp
+                          (set-form 'vector 'offset 'value n-bytes big-endian-p)
+                          (ref-form 'vector 'offset n-bytes signedp big-endian-p)))))))
     (loop for i from 0 to #-x86-64 #b0111 #+x86-64 #b1011
           for bitsize = (ecase (ldb (byte 2 2) i)
                           (0 16)
@@ -59,7 +57,7 @@
           for arg-type = `(,(if signedp
                                 'signed-byte
                                 'unsigned-byte)
-                                ,bitsize)
+                           ,bitsize)
           for arglist = `(vector offset ,@(when setterp '(value)))
           for external-arg-types = `(array index ,@(when setterp
                                                      `(,arg-type)))
@@ -72,25 +70,23 @@
                    ,@(when setterp '(value))))
           for specialized-little-transform
             = (subst internal-little internal-big
-                                     (subst little-fun big-fun
-                                            specialized-big-transform))
+                     (subst little-fun big-fun
+                            specialized-big-transform))
           ;; Also include inlining versions for when the argument type
           ;; is known to be a simple octet vector and we don't have a
           ;; native assembly implementation.
           for generic-big-transform
             = (generic-transform-form big-fun transform-arglist n-bytes
-                      setterp signedp t)
+                                      setterp signedp t)
           for generic-little-transform
             = (generic-transform-form little-fun transform-arglist n-bytes
-                      setterp signedp nil)
+                                      setterp signedp nil)
           if (specialized-includep bitsize signedp setterp)
             collect specialized-big-transform into transforms
           else if (<= bitsize sb-vm:n-word-bits)
-            collect generic-big-transform into transforms
+                 collect generic-big-transform into transforms
           if (specialized-includep bitsize signedp setterp)
             collect specialized-little-transform into transforms
           else if (<= bitsize sb-vm:n-word-bits)
-            collect generic-little-transform into transforms
+                 collect generic-little-transform into transforms
           finally (return `(progn ,@transforms))))
-
-);#+sbcl

--- a/sbcl-opt/x86-64-vm.lisp
+++ b/sbcl-opt/x86-64-vm.lisp
@@ -1,9 +1,6 @@
 ;;;; x86-64-vm.lisp -- VOP definitions SBCL
 
-#+sbcl
-(cl:in-package :sb-vm)
-
-#+(and sbcl x86-64) (progn
+(cl:in-package #:sb-vm)
 
 (define-vop (%check-bound)
   (:translate nibbles::%check-bound)
@@ -61,7 +58,7 @@
                                    (if big-endian-p
                                        'mov
                                        (if signedp 'movsxd 'movzxd)))
-                                   (64 'mov)))
+                                  (64 'mov)))
                   (result-sc (if signedp 'signed-reg 'unsigned-reg))
                   (result-type (if signedp 'signed-num 'unsigned-num)))
              (flet ((movx (insn dest source source-size)
@@ -105,7 +102,7 @@
                            (memref (sc-case index
                                      (immediate
                                       (make-ea ,operand-size :base vector
-                                                            :disp (+ (tn-value index) base-disp)))
+                                                             :disp (+ (tn-value index) base-disp)))
                                      (t
                                       (make-ea ,operand-size
                                                :base vector :index index
@@ -120,8 +117,8 @@
                                                   'value))
                            (movx ref-mov-insn
                                  (if (and big-endian-p (= bitsize 32))
-                                       'result-in-size
-                                       'result)
+                                     'result-in-size
+                                     'result)
                                  'memref operand-size))
                       ,@(if setterp
                             '((move result value*))
@@ -142,5 +139,3 @@
           for big-endian-p = (logbitp 0 i)
           collect (frob bitsize setterp signedp big-endian-p) into forms
           finally (return `(progn ,@forms))))
-
-);#+(and sbcl x86-64)

--- a/sbcl-opt/x86-vm.lisp
+++ b/sbcl-opt/x86-vm.lisp
@@ -1,9 +1,6 @@
 ;;;; x86-vm.lisp -- VOP definitions for SBCL
 
-#+sbcl
-(cl:in-package :sb-vm)
-
-#+(and sbcl x86) (progn
+(cl:in-package #:sb-vm)
 
 (define-vop (%check-bound)
   (:translate nibbles::%check-bound)
@@ -62,10 +59,10 @@
                                 `(,result-type)))
                 ,@(when (or setterp big-endian-p)
                     `((:temporary (:sc unsigned-reg :offset eax-offset
-                                       :from ,(if setterp
-						  '(:load 0)
-						  '(:argument 2))
-                                       :to (:result 0)) eax)))
+                                   :from ,(if setterp
+                                              '(:load 0)
+                                              '(:argument 2))
+                                   :to (:result 0)) eax)))
                 (:results (result :scs (,result-sc)))
                 (:result-types ,result-type)
                 (:generator 3
@@ -74,11 +71,11 @@
                          (memref (sc-case index
                                    (immediate
                                     (make-ea :word :base vector
-                                             :disp (+ (tn-value index) base-disp)))
+                                                   :disp (+ (tn-value index) base-disp)))
                                    (t
                                     (make-ea :word :base vector
-                                             :index index
-                                             :disp base-disp)))))
+                                                   :index index
+                                                   :disp base-disp)))))
                     ,(when setterp
                        '(move eax value))
                     ,(when (and setterp big-endian-p)
@@ -129,8 +126,8 @@
                                 `(,result-type)))
                 ,@(when (and setterp big-endian-p)
                     `((:temporary (:sc unsigned-reg
-                                       :from (:load 0)
-                                       :to (:result 0)) temp)))
+                                   :from (:load 0)
+                                   :to (:result 0)) temp)))
                 (:results (result :scs (,result-sc)))
                 (:result-types ,result-type)
                 (:generator 3
@@ -139,10 +136,10 @@
                          (memref (sc-case index
                                    (immediate
                                     (make-ea :dword :base vector
-                                             :disp (+ (tn-value index) base-disp)))
+                                                    :disp (+ (tn-value index) base-disp)))
                                    (t
                                     (make-ea :dword :base vector :index index
-                                             :disp base-disp)))))
+                                                    :disp base-disp)))))
                     ,@(when (and setterp big-endian-p)
                         `((inst mov temp value)
                           (inst bswap temp)))
@@ -161,5 +158,3 @@
           for big-endian-p = (logbitp 0 i)
           collect (frob setterp signedp big-endian-p) into forms
           finally (return `(progn ,@forms))))
-
-);#+(and sbcl x86)


### PR DESCRIPTION
Instead of adding feature expressions to each file. This way we can avoid wrapping the whole file in a PROGN  for the sole purpose of applying a feature expression to all the forms in a file.