### PR TITLE
Add conditional compilation for sbcl to system definition

### DIFF
--- a/nibbles.asd
+++ b/nibbles.asd
@@ -38,12 +38,13 @@
                         :components ((:html-file "index")
                                      (:txt-file "nibbles-doc")
                                      (:css-file "style")))
+               #+sbcl
                (:module "sbcl-opt"
                         :depends-on ("package" "macro-utils")
                         :components ((:file "fndb")
                                      (:file "nib-tran" :depends-on ("fndb"))
-                                     (:file "x86-vm" :depends-on ("fndb"))
-                                     (:file "x86-64-vm" :depends-on ("fndb")))))
+                                     #+x86 (:file "x86-vm" :depends-on ("fndb"))
+                                     #+x86-64 (:file "x86-64-vm" :depends-on ("fndb")))))
   :in-order-to ((asdf:test-op (asdf:test-op "nibbles/tests")))
   :perform (asdf:prepare-op (component operation)
              ;; nibbles uses SBCL's assembler on x86 and x86-64. The

--- a/sbcl-opt/fndb.lisp
+++ b/sbcl-opt/fndb.lisp
@@ -2,8 +2,6 @@
 
 (cl:in-package :nibbles)
 
-#+sbcl (progn
-
 ;;; Efficient array bounds checking
 (sb-c:defknown %check-bound
   ((simple-array (unsigned-byte 8) (*)) index (and fixnum sb-vm:word)
@@ -42,4 +40,3 @@
                      ,arg-type (sb-c:any) :overwrite-fndb-silently t) into defknowns
         finally (return `(progn ,@defknowns)))
 
-);#+sbcl

--- a/sbcl-opt/nib-tran.lisp
+++ b/sbcl-opt/nib-tran.lisp
@@ -2,8 +2,6 @@
 
 (cl:in-package :nibbles)
 
-#+sbcl (progn
-
 (sb-c:deftransform %check-bound ((vector bound offset n-bytes)
 				 ((simple-array (unsigned-byte 8) (*)) index
 				  (and fixnum sb-vm:word)
@@ -93,4 +91,3 @@
             collect generic-little-transform into transforms
           finally (return `(progn ,@transforms))))
 
-);#+sbcl

--- a/sbcl-opt/x86-64-vm.lisp
+++ b/sbcl-opt/x86-64-vm.lisp
@@ -1,9 +1,6 @@
 ;;;; x86-64-vm.lisp -- VOP definitions SBCL
 
-#+sbcl
 (cl:in-package :sb-vm)
-
-#+(and sbcl x86-64) (progn
 
 (define-vop (%check-bound)
   (:translate nibbles::%check-bound)
@@ -122,4 +119,3 @@
           collect (frob bitsize setterp signedp big-endian-p) into forms
           finally (return `(progn ,@forms))))
 
-);#+(and sbcl x86-64)

--- a/sbcl-opt/x86-vm.lisp
+++ b/sbcl-opt/x86-vm.lisp
@@ -1,9 +1,6 @@
 ;;;; x86-vm.lisp -- VOP definitions for SBCL
 
-#+sbcl
 (cl:in-package :sb-vm)
-
-#+(and sbcl x86) (progn
 
 (define-vop (%check-bound)
   (:translate nibbles::%check-bound)
@@ -162,4 +159,3 @@
           collect (frob setterp signedp big-endian-p) into forms
           finally (return `(progn ,@forms))))
 
-);#+(and sbcl x86)


### PR DESCRIPTION
Fixes clasp-developers/clasp#983
Alternate to #4 in that it works on non ASDF 3 installations.