### PR TITLE
24-bit Accessors

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -6,15 +6,19 @@
            #:make-octet-vector)
   ;; Basic octet vector accessors.
   (:export #:ub16ref/le #:ub16ref/be #:sb16ref/le #:sb16ref/be
+           #:ub24ref/le #:ub24ref/be #:sb24ref/le #:sb24ref/be
            #:ub32ref/le #:ub32ref/be #:sb32ref/le #:sb32ref/be
            #:ub64ref/le #:ub64ref/be #:sb64ref/le #:sb64ref/be)
   ;; Stream readers.
   (:export #:read-ub16/le #:read-ub16/be #:read-sb16/be #:read-sb16/le
+           #:read-ub24/le #:read-ub24/be #:read-sb24/be #:read-sb24/le
            #:read-ub32/le #:read-ub32/be #:read-sb32/be #:read-sb32/le
            #:read-ub64/le #:read-ub64/be #:read-sb64/be #:read-sb64/le)
   ;; Stream readers for vectors.
   (:export #:read-ub16/le-sequence #:read-ub16/be-sequence
            #:read-sb16/le-sequence #:read-sb16/be-sequence
+           #:read-ub24/le-sequence #:read-ub24/be-sequence
+           #:read-sb24/le-sequence #:read-sb24/be-sequence
            #:read-ub32/le-sequence #:read-ub32/be-sequence
            #:read-sb32/le-sequence #:read-sb32/be-sequence
            #:read-ub64/le-sequence #:read-ub64/be-sequence
@@ -22,17 +26,22 @@
   ;; Non-consing variants akin to READ-SEQUENCE.
   (:export #:read-ub16/le-into-sequence #:read-ub16/be-into-sequence
            #:read-sb16/le-into-sequence #:read-sb16/be-into-sequence
+           #:read-ub24/le-into-sequence #:read-ub24/be-into-sequence
+           #:read-sb24/le-into-sequence #:read-sb24/be-into-sequence
            #:read-ub32/le-into-sequence #:read-ub32/be-into-sequence
            #:read-sb32/le-into-sequence #:read-sb32/be-into-sequence
            #:read-ub64/le-into-sequence #:read-ub64/be-into-sequence
            #:read-sb64/le-into-sequence #:read-sb64/be-into-sequence)
   ;; Stream writers.
   (:export #:write-ub16/le #:write-ub16/be #:write-sb16/be #:write-sb16/le
+           #:write-ub24/le #:write-ub24/be #:write-sb24/be #:write-sb24/le
            #:write-ub32/le #:write-ub32/be #:write-sb32/be #:write-sb32/le
            #:write-ub64/le #:write-ub64/be #:write-sb64/be #:write-sb64/le)
   ;; Stream writers for vectors.
   (:export #:write-ub16/le-sequence #:write-ub16/be-sequence
            #:write-sb16/le-sequence #:write-sb16/be-sequence
+           #:write-ub24/le-sequence #:write-ub24/be-sequence
+           #:write-sb24/le-sequence #:write-sb24/be-sequence
            #:write-ub32/le-sequence #:write-ub32/be-sequence
            #:write-sb32/le-sequence #:write-sb32/be-sequence
            #:write-ub64/le-sequence #:write-ub64/be-sequence

--- a/sbcl-opt/fndb.lisp
+++ b/sbcl-opt/fndb.lisp
@@ -5,17 +5,18 @@
 ;;; Efficient array bounds checking
 (sb-c:defknown %check-bound
   ((simple-array (unsigned-byte 8) (*)) index (and fixnum sb-vm:word)
-   (member 2 4 8 16))
+   (member 2 4 3 8 16))
     index (sb-c:any) :overwrite-fndb-silently t)
 
 ;; We DEFKNOWN the exported functions so we can DEFTRANSFORM them.
 ;; We DEFKNOWN the %-functions so we can DEFINE-VOP them.
 
-#.(loop for i from 0 to #-x86-64 #b0111 #+x86-64 #b1011
+#.(loop for i from 0 to #-x86-64 #b1011 #+x86-64 #b1111
         for bitsize = (ecase (ldb (byte 2 2) i)
                         (0 16)
-                        (1 32)
-                        (2 64))
+                        (1 24)
+                        (2 32)
+                        (3 64))
         for signedp = (logbitp 1 i)
         for setterp = (logbitp 0 i)
         for byte-fun = (if setterp

--- a/sbcl-opt/nib-tran.lisp
+++ b/sbcl-opt/nib-tran.lisp
@@ -5,7 +5,7 @@
 (sb-c:deftransform %check-bound ((vector bound offset n-bytes)
 				 ((simple-array (unsigned-byte 8) (*)) index
 				  (and fixnum sb-vm:word)
-				  (member 2 4 8 16))
+				  (member 2 3 4 8 16))
 				 * :node node)
   "optimize away bounds check"
   ;; cf. sb-c::%check-bound transform
@@ -39,11 +39,12 @@
 		 ,',(if setterp
 			(set-form 'vector 'offset 'value n-bytes big-endian-p)
 			(ref-form 'vector 'offset n-bytes signedp big-endian-p)))))))
-    (loop for i from 0 to #-x86-64 #b0111 #+x86-64 #b1011
+    (loop for i from 0 to #-x86-64 #b1011 #+x86-64 #b1111
           for bitsize = (ecase (ldb (byte 2 2) i)
                           (0 16)
-                          (1 32)
-                          (2 64))
+                          (1 24)
+                          (2 32)
+                          (3 64))
           for signedp = (logbitp 1 i)
           for setterp = (logbitp 0 i)
           for byte-fun = (if setterp

--- a/sbcl-opt/x86-64-vm.lisp
+++ b/sbcl-opt/x86-64-vm.lisp
@@ -180,7 +180,7 @@
                           (inst rol :word result 8)
                           (inst ,mov-insn '(:word :qword) result result)
                           (inst shl result 8)
-                          (inst mov result high-memref)))
+                          (inst mov :byte result high-memref)))
                        ((and setterp (not big-endian-p))
                         '((inst mov temp value)
                           (inst mov :word low-memref value)
@@ -190,7 +190,7 @@
                        ((and setterp big-endian-p)
                         '((inst mov temp value)
                           ;; TEMP has the bytes 0 High Mid Low
-                          (inst bswap temp)
+                          (inst bswap :dword temp)
                           ;; L M H 0
                           (inst shr temp 8)
                           ;; 0 L M H

--- a/sbcl-opt/x86-64-vm.lisp
+++ b/sbcl-opt/x86-64-vm.lisp
@@ -9,7 +9,7 @@
          (bound :scs (any-reg))
          (index :scs (any-reg)))
   (:arg-types simple-array-unsigned-byte-8 positive-fixnum tagged-num
-              (:constant (member 2 4 8 16)))
+              (:constant (member 2 3 4 8 16)))
   (:info offset)
   (:temporary (:sc any-reg) temp)
   (:results (result :scs (any-reg)))
@@ -129,4 +129,79 @@
           for signedp = (logbitp 1 i)
           for big-endian-p = (logbitp 0 i)
           collect (frob bitsize setterp signedp big-endian-p) into forms
+          finally (return `(progn ,@forms))))
+
+;;; 24-bit accessors need to be handled specially.
+#.(flet ((frob (setterp signedp big-endian-p)
+           (let* ((name (funcall (if setterp
+                                     #'nibbles::byte-set-fun-name
+                                     #'nibbles::byte-ref-fun-name)
+                                 24 signedp big-endian-p))
+                  (internal-name (nibbles::internalify name))
+                  (result-sc (if signedp 'signed-reg 'unsigned-reg))
+                  (result-type (if signedp 'signed-num 'unsigned-num))
+                  (mov-insn (if signedp 'movsx 'movzx)))
+             `(define-vop (,name)
+                (:translate ,internal-name)
+                (:policy :fast-safe)
+                (:args (vector :scs (descriptor-reg))
+                       (index :scs (immediate unsigned-reg))
+                       ,@(when setterp `((value :scs (,result-sc) :target result))))
+                (:arg-types simple-array-unsigned-byte-8 positive-fixnum
+                            ,@(when setterp `(,result-type)))
+                ,@(when setterp
+                    `((:temporary (:sc unsigned-reg
+                                   :from (:load 0)
+                                   :to (:result 0)) temp)))
+                (:results (result :scs (,result-sc) :from (:load 0)))
+                (:result-types ,result-type)
+                (:generator 3
+                 (let* ((base-disp (- (* vector-data-offset n-word-bytes)
+                                      other-pointer-lowtag))
+                        (low-memref
+                          (sc-case index
+                            (immediate
+                             (ea (+ (tn-value index) base-disp) vector))
+                            (t
+                             (ea base-disp vector index))))
+                        (high-memref
+                          (sc-case index
+                            (immediate
+                             (ea (+ (tn-value index) base-disp 2) vector))
+                            (t
+                             (ea (+ base-disp 2) vector index)))))
+                   ,@(cond
+                       ((and (not setterp) (not big-endian-p))
+                        `((inst ,mov-insn '(:byte :qword) result high-memref)
+                          (inst shl result 16)
+                          (inst mov :word result low-memref)))
+                       ((and (not setterp) big-endian-p)
+                        `((inst mov result low-memref)
+                          (inst rol :word result 8)
+                          (inst ,mov-insn '(:word :qword) result result)
+                          (inst shl result 8)
+                          (inst mov result high-memref)))
+                       ((and setterp (not big-endian-p))
+                        '((inst mov temp value)
+                          (inst mov :word low-memref value)
+                          (inst shr temp 16)
+                          (inst mov :byte high-memref temp)
+                          (move result value)))
+                       ((and setterp big-endian-p)
+                        '((inst mov temp value)
+                          ;; TEMP has the bytes 0 High Mid Low
+                          (inst bswap temp)
+                          ;; L M H 0
+                          (inst shr temp 8)
+                          ;; 0 L M H
+                          (inst mov :word low-memref temp)
+                          (inst shr temp 16)
+                          ;; 0 0 0 L
+                          (inst mov :byte high-memref temp)
+                          (move result value))))))))))
+    (loop for i from 0 upto #b111
+          for setterp = (logbitp 2 i)
+          for signedp = (logbitp 1 i)
+          for big-endian-p = (logbitp 0 i)
+          collect (frob setterp signedp big-endian-p) into forms
           finally (return `(progn ,@forms))))

--- a/streams.lisp
+++ b/streams.lisp
@@ -83,9 +83,10 @@
      (let ((end (or end (length seq))))
        (read-into-vector* stream seq start end n-bytes reffer)))))
 
-#.(loop for i from 0 upto #b10111
+#.(loop for i from 0 upto #b11111
         for bitsize = (ecase (ldb (byte 2 3) i)
                         (0 16)
+                        (3 24)
                         (1 32)
                         (2 64))
         for readp = (logbitp 2 i)

--- a/tests.lisp
+++ b/tests.lisp
@@ -148,6 +148,14 @@
   (ref-test 'nibbles:sb16ref/be 16 t t)
   :ok)
 
+(rtest:deftest :ub24ref/be
+  (ref-test 'nibbles:ub24ref/be 24 nil t)
+  :ok)
+
+(rtest:deftest :sb24ref/be
+  (ref-test 'nibbles:sb24ref/be 24 t t)
+  :ok)
+
 (rtest:deftest :ub32ref/be
   (ref-test 'nibbles:ub32ref/be 32 nil t)
   :ok)
@@ -172,6 +180,14 @@
 
 (rtest:deftest :sb16set/be
   (set-test 'nibbles:sb16ref/be 16 t t)
+  :ok)
+
+(rtest:deftest :ub24set/be
+  (set-test 'nibbles:ub24ref/be 24 nil t)
+  :ok)
+
+(rtest:deftest :sb24set/be
+  (set-test 'nibbles:sb24ref/be 24 t t)
   :ok)
 
 (rtest:deftest :ub32set/be
@@ -200,6 +216,14 @@
   (ref-test 'nibbles:sb16ref/le 16 t nil)
   :ok)
 
+(rtest:deftest :ub24ref/le
+  (ref-test 'nibbles:ub24ref/le 24 nil nil)
+  :ok)
+
+(rtest:deftest :sb24ref/le
+  (ref-test 'nibbles:sb24ref/le 24 t nil)
+  :ok)
+
 (rtest:deftest :ub32ref/le
   (ref-test 'nibbles:ub32ref/le 32 nil nil)
   :ok)
@@ -224,6 +248,14 @@
 
 (rtest:deftest :sb16set/le
   (set-test 'nibbles:sb16ref/le 16 t nil)
+  :ok)
+
+(rtest:deftest :ub24set/le
+  (set-test 'nibbles:ub24ref/le 24 nil nil)
+  :ok)
+
+(rtest:deftest :sb24set/le
+  (set-test 'nibbles:sb24ref/le 24 t nil)
   :ok)
 
 (rtest:deftest :ub32set/le
@@ -459,6 +491,14 @@ denormalized."
   (read-test 'nibbles:read-sb16/be 16 t t)
   :ok)
 
+(rtest:deftest :read-ub24/be
+  (read-test 'nibbles:read-ub24/be 24 nil t)
+  :ok)
+
+(rtest:deftest :read-sb24/be
+  (read-test 'nibbles:read-sb24/be 24 t t)
+  :ok)
+
 (rtest:deftest :read-ub32/be
   (read-test 'nibbles:read-ub32/be 32 nil t)
   :ok)
@@ -507,6 +547,14 @@ denormalized."
   (read-sequence-test 'vector 'nibbles:read-sb16/be-sequence 16 t t)
   :ok)
 
+(rtest:deftest :read-ub24/be-vector
+  (read-sequence-test 'vector 'nibbles:read-ub24/be-sequence 24 nil t)
+  :ok)
+
+(rtest:deftest :read-sb24/be-vector
+  (read-sequence-test 'vector 'nibbles:read-sb24/be-sequence 24 t t)
+  :ok)
+
 (rtest:deftest :read-ub32/be-vector
   (read-sequence-test 'vector 'nibbles:read-ub32/be-sequence 32 nil t)
   :ok)
@@ -529,6 +577,14 @@ denormalized."
 
 (rtest:deftest :read-sb16/le-vector
   (read-sequence-test 'vector 'nibbles:read-sb16/le-sequence 16 t nil)
+  :ok)
+
+(rtest:deftest :read-ub24/le-vector
+  (read-sequence-test 'vector 'nibbles:read-ub24/le-sequence 24 nil nil)
+  :ok)
+
+(rtest:deftest :read-sb24/le-vector
+  (read-sequence-test 'vector 'nibbles:read-sb24/le-sequence 24 t nil)
   :ok)
 
 (rtest:deftest :read-ub32/le-vector
@@ -555,6 +611,14 @@ denormalized."
   (read-sequence-test 'list 'nibbles:read-sb16/be-sequence 16 t t)
   :ok)
 
+(rtest:deftest :read-ub24/be-list
+  (read-sequence-test 'list 'nibbles:read-ub24/be-sequence 24 nil t)
+  :ok)
+
+(rtest:deftest :read-sb24/be-list
+  (read-sequence-test 'list 'nibbles:read-sb24/be-sequence 24 t t)
+  :ok)
+
 (rtest:deftest :read-ub32/be-list
   (read-sequence-test 'list 'nibbles:read-ub32/be-sequence 32 nil t)
   :ok)
@@ -577,6 +641,14 @@ denormalized."
 
 (rtest:deftest :read-sb16/le-list
   (read-sequence-test 'list 'nibbles:read-sb16/le-sequence 16 t nil)
+  :ok)
+
+(rtest:deftest :read-ub24/le-list
+  (read-sequence-test 'list 'nibbles:read-ub24/le-sequence 24 nil nil)
+  :ok)
+
+(rtest:deftest :read-sb24/le-list
+  (read-sequence-test 'list 'nibbles:read-sb24/le-sequence 24 t nil)
   :ok)
 
 (rtest:deftest :read-ub32/le-list
@@ -668,6 +740,14 @@ denormalized."
   (write-test 'nibbles:write-sb16/be 16 t t)
   :ok)
 
+(rtest:deftest :write-ub24/be
+  (write-test 'nibbles:write-ub24/be 24 nil t)
+  :ok)
+
+(rtest:deftest :write-sb24/be
+  (write-test 'nibbles:write-sb24/be 24 t t)
+  :ok)
+
 (rtest:deftest :write-ub32/be
   (write-test 'nibbles:write-ub32/be 32 nil t)
   :ok)
@@ -690,6 +770,14 @@ denormalized."
 
 (rtest:deftest :write-sb16/le
   (write-test 'nibbles:write-sb16/le 16 t nil)
+  :ok)
+
+(rtest:deftest :write-ub24/le
+  (write-test 'nibbles:write-ub24/le 24 nil nil)
+  :ok)
+
+(rtest:deftest :write-sb24/le
+  (write-test 'nibbles:write-sb24/le 24 t nil)
   :ok)
 
 (rtest:deftest :write-ub32/le
@@ -718,6 +806,18 @@ denormalized."
   (write-sequence-test 'vector
 		       'nibbles:read-sb16/be-sequence
 		       'nibbles:write-sb16/be-sequence 16 t t)
+  :ok)
+
+(rtest:deftest :write-ub24/be-vector
+  (write-sequence-test 'vector
+  	                   'nibbles:read-ub24/be-sequence
+  	                   'nibbles:write-ub24/be-sequence 24 nil t)
+  :ok)
+
+(rtest:deftest :write-sb24/be-vector
+  (write-sequence-test 'vector
+		               'nibbles:read-sb24/be-sequence
+		               'nibbles:write-sb24/be-sequence 24 t t)
   :ok)
 
 (rtest:deftest :write-ub32/be-vector
@@ -756,6 +856,18 @@ denormalized."
 		       'nibbles:write-sb16/le-sequence 16 t nil)
   :ok)
 
+(rtest:deftest :write-ub24/le-vector
+  (write-sequence-test 'vector
+  	                   'nibbles:read-ub24/le-sequence
+  	                   'nibbles:write-ub24/le-sequence 24 nil nil)
+  :ok)
+
+(rtest:deftest :write-sb24/le-vector
+  (write-sequence-test 'vector
+		               'nibbles:read-sb24/le-sequence
+		               'nibbles:write-sb24/le-sequence 24 t nil)
+  :ok)
+
 (rtest:deftest :write-ub32/le-vector
   (write-sequence-test 'vector
 		       'nibbles:read-ub32/le-sequence
@@ -792,6 +904,18 @@ denormalized."
 		       'nibbles:write-sb16/be-sequence 16 t t)
   :ok)
 
+(rtest:deftest :write-ub24/be-list
+  (write-sequence-test 'list
+		               'nibbles:read-ub24/be-sequence
+		               'nibbles:write-ub24/be-sequence 24 nil t)
+  :ok)
+
+(rtest:deftest :write-sb24/be-list
+  (write-sequence-test 'list
+		               'nibbles:read-sb24/be-sequence
+		               'nibbles:write-sb24/be-sequence 24 t t)
+  :ok)
+
 (rtest:deftest :write-ub32/be-list
   (write-sequence-test 'list
 		       'nibbles:read-ub32/be-sequence
@@ -826,6 +950,18 @@ denormalized."
   (write-sequence-test 'list
 		       'nibbles:read-sb16/le-sequence
 		       'nibbles:write-sb16/le-sequence 16 t nil)
+  :ok)
+
+(rtest:deftest :write-ub24/le-list
+  (write-sequence-test 'list
+		               'nibbles:read-ub24/le-sequence
+		               'nibbles:write-ub24/le-sequence 24 nil nil)
+  :ok)
+
+(rtest:deftest :write-sb24/le-list
+  (write-sequence-test 'list
+		               'nibbles:read-sb24/le-sequence
+		               'nibbles:write-sb24/le-sequence 24 t nil)
   :ok)
 
 (rtest:deftest :write-ub32/le-list

--- a/vectors.lisp
+++ b/vectors.lisp
@@ -52,6 +52,7 @@
                      collect `(define-storer ,bitsize ,signedp ,big-endian-p) into forms
                      finally (return `(progn ,@forms)))))
   (define-fetchers-and-storers 16)
+  (define-fetchers-and-storers 24)
   (define-fetchers-and-storers 32)
   (define-fetchers-and-storers 64))
 


### PR DESCRIPTION
Audio formats and other binary formats still frequently make use of 24-bit integers. It would be great if nibbles could include support for them too, so here's a PR for that.

The tests pass with these changes already, ~~though I'll also look at updating the SBCL optimisations to support 24-bit as well tomorrow.~~
Thanks to Hayley for implementing the vops!