### PR TITLE
CLISP does not support subnormal floating point numbers.

### DIFF
--- a/nibbles.asd
+++ b/nibbles.asd
@@ -20,7 +20,7 @@
   (call-next-method))
 
 (asdf:defsystem "nibbles"
-  :version "0.15"
+  :version "0.16"
   :author "Nathan Froyd <froydnj@gmail.com>"
   :maintainer "Sharp Lispers <sharplispers@googlegroups.com>"
   :description "A library for accessing octet-addressed blocks of data in big- and little-endian orders"


### PR DESCRIPTION
Signal an error on CLISP when MAKE-SINGLE-FLOAT and MAKE-DOUBLE-FLOAT are called with bit patterns that represent subnormal floating point numbers.

Also, improve the error messages for bit patterns that represent floating point infinities and NaNs.